### PR TITLE
feat: sign custom Ely property

### DIFF
--- a/internal/http/mojang_api.go
+++ b/internal/http/mojang_api.go
@@ -154,9 +154,9 @@ func (s *MojangApi) createProfileResponse(
 				return nil, fmt.Errorf("unable to sign custom property: %w", err)
 			}
 		}
-		result = fmt.Appendf(result, `},{"name":"ely","value":"but why are you asking?","signature":%q}]}`, customPropertySignature)
+		result = fmt.Appendf(result, `},{"name":"ely","value":%q,"signature":%q}]}`, customPropertyValue, customPropertySignature)
 	} else {
-		result = fmt.Appendf(result, `},{"name":"ely","value":"but why are you asking?"}]}`)
+		result = fmt.Appendf(result, `},{"name":"ely","value":%q}]}`, customPropertyValue)
 	}
 
 	return result, nil

--- a/internal/http/mojang_api.go
+++ b/internal/http/mojang_api.go
@@ -15,9 +15,7 @@ import (
 var timeNow = time.Now
 
 var emptyTextures = []byte("{}")
-
 var customPropertyValue = []byte("but why are you asking?")
-var customPropertySignature []byte = nil
 
 type AccountsRepository interface {
 	FindUsernameByUuid(ctx context.Context, uuid string) (string, error)
@@ -86,7 +84,7 @@ func (s *MojangApi) getProfileByUuidHandler(c *gin.Context) {
 		textures = emptyTextures
 	}
 
-	serializedProfile, err := s.createProfileResponse(uuid, username, textures, c.Query("unsigned") == "false")
+	serializedProfile, err := s.createProfileResponse(c.Request.Context(), uuid, username, textures, c.Query("unsigned") == "false")
 	if err != nil {
 		c.Error(fmt.Errorf("unable to create a profile response: %w", err))
 		return
@@ -114,6 +112,7 @@ func (s *MojangApi) getUuidByUsernameHandler(c *gin.Context) {
 }
 
 func (s *MojangApi) createProfileResponse(
+	ctx context.Context,
 	uuid string,
 	username string,
 	texturesJson []byte,
@@ -142,28 +141,35 @@ func (s *MojangApi) createProfileResponse(
 	)
 
 	if sign {
-		textureSignature, err := s.signAndEncodeBase64(encodedTexturesBuf)
+		textureSignature, err := s.signAndEncodeBase64(ctx, encodedTexturesBuf)
 		if err != nil {
 			return nil, fmt.Errorf("unable to sign textures: %w", err)
 		}
-		result = fmt.Appendf(result, `,"signature":%q`, textureSignature)
 
-		if customPropertySignature == nil {
-			customPropertySignature, err = s.signAndEncodeBase64(customPropertyValue)
-			if err != nil {
-				return nil, fmt.Errorf("unable to sign custom property: %w", err)
-			}
-		}
-		result = fmt.Appendf(result, `},{"name":"ely","value":%q,"signature":%q}]}`, customPropertyValue, customPropertySignature)
-	} else {
-		result = fmt.Appendf(result, `},{"name":"ely","value":%q}]}`, customPropertyValue)
+		result = fmt.Appendf(result, `,"signature":%q`, textureSignature)
 	}
+
+	result = fmt.Appendf(result, `},{"name":"ely","value":%q`, customPropertyValue)
+
+	if sign {
+		// Despite the fact that the signed value itself is always the same,
+		// the signature service may rotate keys and at some point the signature will change.
+		// It is better to avoid the cache for now and add it on the signature service side later.
+		customPropertySignature, err := s.signAndEncodeBase64(ctx, customPropertyValue)
+		if err != nil {
+			return nil, fmt.Errorf("unable to sign custom property: %w", err)
+		}
+
+		result = fmt.Appendf(result, `,"signature":%q`, customPropertySignature)
+	}
+
+	result = fmt.Appendf(result, `}]}`)
 
 	return result, nil
 }
 
-func (s *MojangApi) signAndEncodeBase64(data []byte) ([]byte, error) {
-	signature, err := s.SignerService.Sign(context.Background(), data)
+func (s *MojangApi) signAndEncodeBase64(ctx context.Context, data []byte) ([]byte, error) {
+	signature, err := s.SignerService.Sign(ctx, data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The custom Ely property (`"ely"`->`"but why are you asking?"`) is now signed. The signature is generated once when it's first needed and then cached until the application restarts.

Closes #1 