### PR TITLE
Revert "Add missing UUID lookup endpoint"

### DIFF
--- a/internal/http/mojang_api.go
+++ b/internal/http/mojang_api.go
@@ -54,8 +54,6 @@ func NewMojangApi(
 func (s *MojangApi) DefineRoutes(r gin.IRouter) {
 	// https://sessionserver.mojang.com/session/minecraft/profile/:uuid
 	r.GET("/session/minecraft/profile/:uuid", s.getProfileByUuidHandler)
-	// https://api.minecraftservices.com/minecraft/profile/lookup/:uuid
-	r.GET("/minecraft/profile/lookup/:uuid", s.getProfileByUuidHandler)
 
 	// https://api.mojang.com/users/profiles/minecraft/:username
 	r.GET("/users/profiles/minecraft/:username", s.getUuidByUsernameHandler)


### PR DESCRIPTION
This reverts commit 09768195f6574be429c2269d6407ea32d156ee0e.

The endpoint is a username-by-uuid endpoint, not a profile-by-uuid: https://minecraft.wiki/w/Mojang_API#Query_player's_UUID